### PR TITLE
When used with the apostrophe-workflow module, apostrophe-blocks now …

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ function Blocks(options, callback) {
           type: type,
           id: id
         });
-        return self._apos.putPage(req, slug, page, callback);
+        return self._apos.putPage(req, slug, { workflow:[ 'blockGroups' ] }, page, callback);
       }
     }, function(err) {
       if (err) {
@@ -189,7 +189,7 @@ function Blocks(options, callback) {
             block.type = type;
           }
         });
-        return self._apos.putPage(req, slug, page, callback);
+        return self._apos.putPage(req, slug, { workflow: [ 'blockGroups' ] }, page, callback);
       }
     }, function(err) {
       if (err) {
@@ -228,7 +228,7 @@ function Blocks(options, callback) {
         page.blockGroups[group].blocks = _.filter(page.blockGroups[group].blocks, function(block) {
           return (block.id !== id);
         });
-        return self._apos.putPage(req, slug, page, callback);
+        return self._apos.putPage(req, slug, { workflow: [ 'blockGroups' ] }, page, callback);
       }
     }, function(err) {
       if (err) {
@@ -264,7 +264,7 @@ function Blocks(options, callback) {
           return callback('notfound');
         }
         page.blockGroups[group].blocks = self._apos.orderById(ids, page.blockGroups[group].blocks, 'id');
-        return self._apos.putPage(req, slug, page, callback);
+        return self._apos.putPage(req, slug, { workflow: [ 'blockGroups' ] }, page, callback);
       }
     }, function(err) {
       if (err) {


### PR DESCRIPTION
…supports workflow properly and does not prematurely publish content when users switch the type of an existing block, which would otherwise expose text that had not been approved. Workflow also applies to adding, removing and reordering blocks although these were less urgent because they did not expose unapproved text.
